### PR TITLE
Move tempdir to dev-dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gitignore"
-version = "1.0.2"
+version = "1.0.3"
 authors = ["Nathan Kleyn <nathan@nathankleyn.com>"]
 description = "Implementation of .gitignore file parsing and glob testing in Rust."
 license = "MIT"
@@ -9,6 +9,8 @@ repository = "https://github.com/nathankleyn/gitignore.rs"
 
 [dependencies]
 glob = "0.2.10"
+
+[dev-dependencies]
 tempdir = "0.3.0"
 
 [features]


### PR DESCRIPTION
Dev dependencies are loaded for test and bench builds but not for
regular builds. Skipping tempdir saves tens of seconds on build time on
an older laptop.
