### PR TITLE
Handle case when a nested file is not excluded by negation rules

### DIFF
--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -231,6 +231,30 @@ mod tests {
         assert!(!gip.is_excluded(Path::new("foo"), false));
     }
 
+    #[test]
+    fn test_double_star_matches_nested_dir() {
+        let gip = Pattern::new("foo/**", Path::new("/")).unwrap();
+        assert!(gip.is_excluded(Path::new("foo/bar"), true));
+    }
+
+    #[test]
+    fn test_negate_double_star_matches_nested_dir() {
+        let gip = Pattern::new("!foo/**", Path::new("/")).unwrap();
+        assert!(!gip.is_excluded(Path::new("foo/bar"), true));
+    }
+
+    #[test]
+    fn test_double_star_matches_nested_file() {
+        let gip = Pattern::new("foo/**", Path::new("/")).unwrap();
+        assert!(gip.is_excluded(Path::new("foo/bar/index.html"), false));
+    }
+
+    #[test]
+    fn test_negate_double_star_matches_nested_file() {
+        let gip = Pattern::new("!foo/**", Path::new("/")).unwrap();
+        assert!(!gip.is_excluded(Path::new("foo/bar/index.html"), false));
+    }
+
     #[cfg(feature = "nightly")]
     #[bench]
     fn bench_pattern_new(b: &mut Bencher) {


### PR DESCRIPTION
A file can be included if all its parents dirs are included and the file itself is included by negated patterns.
This commit adds a test to check for this case.


Given this dir structure
```
├── .gitignore
└── assets
    └── foo
        └── bar.html
```

and this .gitignore file:
```gitignore
*
!assets/
!assets/**
!.git*
```

`assets/foo/bar.html` should be in the included list